### PR TITLE
Create `include_file` method instead of `load`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Method `host` generate `Host` directive. First argument is name of host, Second 
 
 ### Splitting files
 
-You can use `load` method to load other Nymphia file like following example. Absolute path and relative path are acceptable as the file path.
+You can use `include_file` method to include other Nymphia file like following example. Absolute path and relative path are acceptable as the file path.
+
+We could use `load` in previous version, but `load` is obsoleted now.
 
 ```ruby
 identity_file :private, '~/.ssh/id_rsa.1'
@@ -77,7 +79,7 @@ host('alice', 'my server on VPS') {
   use_identify_file :private
 }
 
-load 'other_nymphia_file.rb'
+include_file 'other_nymphia_file.rb'
 ```
 
 ### Proxy method

--- a/examples/base.rb
+++ b/examples/base.rb
@@ -16,4 +16,4 @@ host('queen', 'NAS in my home network') {
   use_identify_file :private
 }
 
-load 'company.rb'
+include_file 'company.rb'

--- a/lib/nymphia/dsl/context.rb
+++ b/lib/nymphia/dsl/context.rb
@@ -37,6 +37,11 @@ class Nymphia::DSL::Context
   end
 
   def load(load_file_path)
+    warn "#{caller[0]}: #load method is obsolated. Use #include_file"
+    include_file(load_file_path)
+  end
+
+  def include_file(load_file_path)
     absolute_load_file_path = Pathname.new(@path).dirname.join(load_file_path)
     dsl_code = File.read(absolute_load_file_path)
 

--- a/spec/nymphia/cli_spec.rb
+++ b/spec/nymphia/cli_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Nymphia::DSL do
-
   describe '#run' do
     context 'when -f is given' do
       subject(:cli) { Nymphia::CLI.new(['-f', 'examples/base.rb']) }

--- a/spec/nymphia/dsl/context_spec.rb
+++ b/spec/nymphia/dsl/context_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Nymphia::DSL::Context do
+  context 'Loading DSL file has `load` method' do
+    it 'emits warning message' do
+      expect {
+        Nymphia::DSL::Context.eval('load "examples/company.rb"', 'dummy')
+      }.to output(/#load method is obsolated. Use #include_file/).to_stderr_from_any_process
+    end
+  end
+end


### PR DESCRIPTION
`load` method is ambiguous because Ruby has `Kernel#.load` method. 

So I introduce `include_file` method and let Nymphia to warn when `load` method is used in loaded file.